### PR TITLE
Temporary fix version of ansible to avoid fatal errors during vagrant up

### DIFF
--- a/provisioning/shell/ansible.sh
+++ b/provisioning/shell/ansible.sh
@@ -26,6 +26,6 @@ echo "Installing required python modules."
 pip install paramiko pyyaml jinja2 markupsafe MySQL-python
 
 echo "Installing Ansible."
-pip install ansible
+pip install ansible=1.9.4
 
 echo 'Finished installing ansible'


### PR DESCRIPTION
I've temporary fixed version ansible to 1.9.4
Because, after ansible 2.0 release, php install is failing.
